### PR TITLE
#2 fix import templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+package-lock.json

--- a/src/linagora.esn.unifiedinbox/app/directives/main.js
+++ b/src/linagora.esn.unifiedinbox/app/directives/main.js
@@ -387,19 +387,6 @@ angular.module('linagora.esn.unifiedinbox')
     };
   })
 
-  .directive('emailBodyEditor', function(emailBodyService) {
-    function template(name) {
-      return '/unifiedinbox/views/composer/editor/' + name + '.html';
-    }
-
-    return {
-      restrict: 'E',
-      templateUrl: function() {
-        return emailBodyService.supportsRichtext() ? template('richtext') : template('plaintext');
-      }
-    };
-  })
-
   .directive('inboxStar', function(inboxJmapItemService) {
     return {
       restrict: 'E',

--- a/src/linagora.esn.unifiedinbox/app/directives/subheaders.js
+++ b/src/linagora.esn.unifiedinbox/app/directives/subheaders.js
@@ -39,13 +39,6 @@ angular.module('linagora.esn.unifiedinbox')
     };
   })
 
-  .directive('fullscreenEditFormSubheader', function() {
-    return {
-      restrict: 'E',
-      templateUrl: '/unifiedinbox/views/composer/fullscreen-edit-form/subheader.html'
-    };
-  })
-
   .directive('inboxSubheaderCloseButton', function() {
     return {
       restrict: 'E',

--- a/src/linagora.esn.unifiedinbox/app/providers.js
+++ b/src/linagora.esn.unifiedinbox/app/providers.js
@@ -228,8 +228,8 @@ angular.module('linagora.esn.unifiedinbox')
     return inboxNewMessageProvider('/unifiedinbox/views/unified-inbox/elements/message', computeUniqueSetOfRecipients);
   })
 
-  .factory('inboxHostedMailAttachmentProvider', function(withJmapClient, pagedJmapRequest, newProvider, ByDateElementGroupingTool,
-                                                         inboxFilteringService, inboxMailboxesService, inboxJmapProviderContextBuilder,
+  .factory('inboxHostedMailAttachmentProvider', function(withJmapClient, pagedJmapRequest, newProvider,
+                                                         inboxMailboxesService, inboxJmapProviderContextBuilder,
                                                          JMAP_GET_MESSAGES_ATTACHMENTS_LIST, ELEMENTS_PER_REQUEST, PROVIDER_TYPES) {
     return newProvider({
       type: PROVIDER_TYPES.JMAP,

--- a/src/linagora.esn.unifiedinbox/app/providers.js
+++ b/src/linagora.esn.unifiedinbox/app/providers.js
@@ -225,7 +225,7 @@ angular.module('linagora.esn.unifiedinbox')
   })
 
   .factory('inboxHostedMailMessagesProvider', function(inboxNewMessageProvider, computeUniqueSetOfRecipients) {
-    return inboxNewMessageProvider('/unifiedinbox/views/unified-inbox/elements/message', computeUniqueSetOfRecipients);
+    return inboxNewMessageProvider('/unifiedinbox/views/unified-inbox/elements/message.html', computeUniqueSetOfRecipients);
   })
 
   .factory('inboxHostedMailAttachmentProvider', function(withJmapClient, pagedJmapRequest, newProvider,
@@ -254,7 +254,7 @@ angular.module('linagora.esn.unifiedinbox')
       buildFetchContext: function(options) {
         return (options.id && inboxMailboxesService.getMessageListFilter(options.id)) || inboxJmapProviderContextBuilder(options);
       },
-      templateUrl: '/unifiedinbox/views/components/sidebar/attachment/sidebar-attachment-item'
+      templateUrl: '/unifiedinbox/views/components/sidebar/attachment/sidebar-attachment-item.html'
     });
   })
 

--- a/src/linagora.esn.unifiedinbox/app/routes.js
+++ b/src/linagora.esn.unifiedinbox/app/routes.js
@@ -266,7 +266,7 @@
             item: undefined,
             selection: false
           }
-        }, '/unifiedinbox/views/email/view/move/index', 'inboxMoveItemController'))
+        }, '/unifiedinbox/views/email/view/move/index.html', 'inboxMoveItemController'))
         .state('unifiedinbox.inbox.message', stateOpeningListItem({
           url: '/:emailId',
           views: {
@@ -278,6 +278,6 @@
         }))
         .state('unifiedinbox.inbox.message.move', stateOpeningModal({
           url: '/move'
-        }, '/unifiedinbox/views/email/view/move/index', 'inboxMoveItemController'));
+        }, '/unifiedinbox/views/email/view/move/index.html', 'inboxMoveItemController'));
     });
 })(angular);

--- a/src/linagora.esn.unifiedinbox/app/run.js
+++ b/src/linagora.esn.unifiedinbox/app/run.js
@@ -37,5 +37,35 @@
 
     .run(function(inboxEmailSendingHookService, emailSendingService) {
       inboxEmailSendingHookService.registerPreSendingHook(emailSendingService.handleInlineImageBeforeSending);
+    })
+    
+    .run(function($templateCache) {
+      $templateCache.put('/unifiedinbox/app/components/composer/boxed/composer-boxed.html', require('./components/composer/boxed/composer-boxed.pug'));
+      $templateCache.put('/unifiedinbox/views/components/sidebar/attachment/sidebar-attachment-item.html', require('./components/sidebar/attachment/sidebar-attachment-item.pug'));
+      $templateCache.put('/unifiedinbox/app/search/form/search-form-template.html', require('./search/form/search-form-template.pug'));
+      $templateCache.put('/unifiedinbox/app/components/attachment-alternative-uploader/attachment-alternative-uploader-modal-no-uploader.html', require('./components/attachment-alternative-uploader/attachment-alternative-uploader-modal-no-uploader.pug'));
+      $templateCache.put('/unifiedinbox/app/components/attachment-alternative-uploader/attachment-alternative-uploader-modal.html', require('./components/attachment-alternative-uploader/attachment-alternative-uploader-modal.pug'));
+      $templateCache.put('/unifiedinbox/app/components/composer/composer-desktop.html', require('./components/composer/composer-desktop.pug'));
+      $templateCache.put('/unifiedinbox/app/components/composer/composer-mobile.html', require('./components/composer/composer-mobile.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/empty-messages/containers/inbox.html', require('../views/partials/empty-messages/containers/inbox.pug'));
+      $templateCache.put('/unifiedinbox/views/email/view/action-list.html', require('../views/email/view/action-list.pug'));
+      $templateCache.put('/unifiedinbox/views/email/view/action-list-subheader.html', require('../views/email/view/action-list-subheader.pug'));
+      $templateCache.put('/unifiedinbox/views/email/view/move/index.html', require('../views/email/view/move/index.pug'));
+      $templateCache.put('/unifiedinbox/views/components/sidebar/attachment/sidebar-attachment.html', require('./components/sidebar/attachment/sidebar-attachment.pug'));
+      $templateCache.put('/unifiedinbox/views/folders/edit/index.html', require('../views/folders/edit/index.pug'));
+      $templateCache.put('/unifiedinbox/views/folders/delete/index.html', require('../views/folders/delete/index.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/swipe/left-template-markAsRead.html', require('../views/partials/swipe/left-template-markAsRead.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/swipe/left-template-moveToTrash.html', require('../views/partials/swipe/left-template-moveToTrash.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/quotes/original.html', require('../views/partials/quotes/original.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/quotes/default.html', require('../views/partials/quotes/default.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/quotes/defaultText.html', require('../views/partials/quotes/defaultText.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/quotes/forward.html', require('../views/partials/quotes/forward.pug'));
+      $templateCache.put('/unifiedinbox/views/partials/quotes/forwardText.html', require('../views/partials/quotes/forwardText.pug'));
+      $templateCache.put('/unifiedinbox/views/sidebar/sidebar-menu.html', require('../views/sidebar/sidebar-menu.pug'));
+      $templateCache.put('/unifiedinbox/views/attachment/attachment-action-list.html', require('../views/attachment/attachment-action-list.pug'));
+      $templateCache.put('/unifiedinbox/views/filter/dropdown-list.html', require('../views/filter/dropdown-list.pug'));
+      $templateCache.put('/unifiedinbox/views/folders/add/index.html', require('../views/folders/add/index.pug'));
+      $templateCache.put('/unifiedinbox/views/thread/view/action-list.html', require('../views/thread/view/action-list.pug'));
+      $templateCache.put('/unifiedinbox/views/unified-inbox/action-list.html', require('../views/unified-inbox/action-list.pug'));
     });
 })(angular);

--- a/src/linagora.esn.unifiedinbox/app/search/plugin/search-plugin.run.js
+++ b/src/linagora.esn.unifiedinbox/app/search/plugin/search-plugin.run.js
@@ -1,10 +1,15 @@
 (function(angular) {
   'use strict';
 
-  angular.module('linagora.esn.unifiedinbox').run(runBlock);
+  angular.module('linagora.esn.unifiedinbox')
+    .run(addInboxSearchPlugin)
+    .run(addTemplateCache);
 
-  function runBlock(inboxPlugins, inboxSearchPluginService) {
+  function addInboxSearchPlugin(inboxPlugins, inboxSearchPluginService) {
     inboxPlugins.add(inboxSearchPluginService());
   }
 
+  function addTemplateCache($templateCache) {
+    $templateCache.put('/unifiedinbox/app/search/empty/search-empty-message.html', require('../empty/search-empty-message.pug'));
+  }
 })(angular);

--- a/src/linagora.esn.unifiedinbox/app/search/search.run.js
+++ b/src/linagora.esn.unifiedinbox/app/search/search.run.js
@@ -1,9 +1,15 @@
 (function(angular) {
   'use strict';
 
-  angular.module('linagora.esn.unifiedinbox').run(runBlock);
+  angular.module('linagora.esn.unifiedinbox')
+    .run(addInboxSearchProvider)
+    .run(addTemplateCache);
 
-  function runBlock(searchProviders, inboxSearchResultsProvider) {
+  function addInboxSearchProvider(searchProviders, inboxSearchResultsProvider) {
     searchProviders.add(inboxSearchResultsProvider);
+  }
+
+  function addTemplateCache($templateCache) {
+    $templateCache.put('/unifiedinbox/views/unified-inbox/elements/message.html', require('../../views/unified-inbox/elements/message.pug'));
   }
 })(angular);

--- a/src/linagora.esn.unifiedinbox/app/services/plugins/jmap/jmap-plugin.run.js
+++ b/src/linagora.esn.unifiedinbox/app/services/plugins/jmap/jmap-plugin.run.js
@@ -23,6 +23,10 @@
           });
         }
       });
-    });
+    })
 
+    .run(function($templateCache) {
+      $templateCache.put('/unifiedinbox/app/services/plugins/jmap/jmap-empty-message.html', require('./jmap-empty-message.pug'));
+      $templateCache.put('/unifiedinbox/app/services/plugins/jmap/jmap-empty-message-custom-folder.html', require('./jmap-empty-message-custom-folder.pug'));
+    })
 })();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -250,9 +250,6 @@ module.exports = {
         exclude: /assets\/index\.pug$/,
         use: [
           {
-            loader: 'apply-loader',
-          },
-          {
             loader: 'pug-loader',
             options: pugLoaderOptions
           },


### PR DESCRIPTION
Fix template import

This PR cache not only templates that are used by `templateUrl` but also the dynamic/ng-include templates like:

```
inbox-subheader-more-button(action-list="/unifiedinbox/views/thread/view/action-list.html")
```

**TODO:**

- [x] Fix the include syntax in pug file
```
include jmap-empty-message.pug

.message.inbox-dnd-info-message.all-centered.hidden-xs
  i.mdi.mdi-lightbulb-outline
  span {{ 'Did you know you can drag & drop messages to this folder? Give it a try!' | translate }}
```