### PR TITLE
esn-frontend-inbox/issues/34: Added the usage of dotenv to load environment variables from the .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+APP_GRID_ITEMS=[{ "name": "Calendar", "url": "http://localhost:9900/#/calendar" }, { "name": "Contacts", "url": "http://localhost:9900/#/contacts" }, { "name": "Inbox", "url": "http://localhost:9900/#/unifiedinbox/inbox" }, { "name": "Admin", "url": "http://localhost:9900/#/admin" }, { "name": "LinShare", "url": "http://localhost:30000" }]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dist
 package-lock.json
+.env

--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ Webmail application for OpenPaaS
 
 ## Development
 
-Launch the dev server on http://localhost:9900:
+First, you want to ensure that the application grid component is provided with the necessary information about the apps via the environment variable `APP_GRID_ITEMS`:
+
+```sh
+cp .env.example .env
+```
+
+- **APP_GRID_ITEMS**: A stringified JSON representation of the apps to show in the application grid. It has the following shape:
+  ```json
+  [
+    { "name": "Inbox", "url": "http://localhost:9900/#/unifiedinbox/inbox" },
+    { "name": "Calendar", "url": "http://localhost:9900/#/calendar" },
+    ...
+  ]
+  ```
+
+Then, launch the dev server on http://localhost:9900:
 
 ```sh
 OPENPAAS_URL=https://dev.open-paas.org npm run serve
@@ -24,4 +39,10 @@ Generates minified SPA in the `./dist` folder:
 
 ```sh
 npm run build:prod
+```
+
+Regarding **APP_GRID_ITEMS**, you can also provide it as a system variable for production purposes, e.g.:
+
+```sh
+APP_GRID_ITEMS="[{ \"name\": \"Calendar\", \"url\": \"https://dev.open-paas.org/calendar/\" }, { \"name\": \"Contacts\", \"url\": \"https://dev.open-paas.org/contacts/\" }, { \"name\": \"Inbox\", \"url\": \"http://dev.open-paas.org/inbox/\" }, { \"name\": \"Admin\", \"url\": \"https://dev.open-paas.org/admin/\" }, { \"name\": \"LinShare\", \"url\": \"https://user.linshare-4-0.integration-linshare.org/\" }]" npm run build:prod
 ```

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^3.6.0",
     "esn-frontend-login": "github:openpaas-suite/esn-frontend-login#main",
+    "dotenv-webpack": "^2.0.0",
     "exports-loader": "^1.0.0",
     "expose-loader": "^1.0.0",
     "favicons-webpack-plugin": "^3.0.1",

--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 
 const commonLibsPath = path.resolve(__dirname, 'node_modules', 'esn-frontend-common-libs');
 const angularCommon = path.resolve(__dirname, 'node_modules', 'esn-frontend-common-libs', 'src', 'angular-common.js');
@@ -29,6 +30,7 @@ module.exports = {
     },
   },
   plugins: [
+    new Dotenv({ systemvars: true }),
     new webpack.IgnorePlugin({ resourceRegExp: /codemirror/ }), // for summernote
     new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
     new webpack.ProvidePlugin({


### PR DESCRIPTION
Added the usage of dotenv to load environment variables from the .env file.

Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/pull/61 as it is needed for this PR to work.

- Demo video:

[
![Demo-Application-Grid-SystemVars](https://user-images.githubusercontent.com/24670327/88533715-ecea3100-d030-11ea-94b8-562bd7da50c6.gif)
](https://streamable.com/4064mq)