### PR TITLE
esn-frontend-mailto#2: Added onSending and onFail callbacks in composer controller

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/components/composer/boxed/composer-boxed.pug
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/boxed/composer-boxed.pug
@@ -4,7 +4,9 @@ inbox-composer(
   message="email",
   on-hide="$hide()",
   on-show="$show()",
+  on-sending="onSending()",
   on-send="onSend()",
+  on-fail="onFail()"
   on-discard="onDiscard()",
   on-message-id-update="$setId($id)",
   on-title-update="$updateTitle($title)",

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
@@ -8,6 +8,7 @@ require('../../services/attachment-provider-registry/attachment-provider-registr
 require('../../services/hook/email-composing-hook.service.js');
 require('../../services/attachment-jmap/attachment-jmap.constants.js');
 
+// TODO: Write tests for this (https://github.com/OpenPaaS-Suite/esn-frontend-mailto/issues/2)
 (function(angular) {
   'use strict';
 
@@ -134,6 +135,8 @@ require('../../services/attachment-jmap/attachment-jmap.constants.js');
             progressing: 'Your message is being sent...',
             success: 'Message sent',
             failure: function() {
+              if (typeof self.onFail === 'function') self.onFail();
+
               if (!Offline.state || Offline.state === 'down') {
                 return 'You have been disconnected. Please check if the message was sent before retrying';
               }
@@ -141,6 +144,8 @@ require('../../services/attachment-jmap/attachment-jmap.constants.js');
               return 'Your message cannot be sent';
             }
           }, function() {
+            if (typeof self.onSending === 'function') self.onSending();
+
             return waitUntilMessageIsComplete(self.message)
               .then(_quoteOriginalEmailIfNeeded)
               .then(emailSendingService.sendEmail.bind(emailSendingService, self.message));

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.js
@@ -8,7 +8,9 @@
       controller: 'inboxComposerController',
       bindings: {
         message: '<',
+        onSending: '&',
         onSend: '&',
+        onFail: '&',
         onSave: '&',
         onDiscard: '&',
         onHide: '&',


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-mailto/issues/2.

Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-mailto/pull/14 for the demonstration.