### PR TITLE
esn-frontend-inbox#53: Brought back the Linshare upload provider in the mail composer

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dompurify": "1.0.9",
     "esn-frontend-common-libs": "github:openpaas-suite/esn-frontend-common-libs#main",
     "esn-frontend-inbox-calendar": "github:openpaas-suite/esn-frontend-inbox-calendar#main",
+    "esn-frontend-inbox-linshare": "github:openpaas-suite/esn-frontend-inbox-linshare#main",
     "jmap-draft-client": "^0.1.2",
     "sanitize-html": "github:linagora/sanitize-html#c89d4ebe09da48296f33cc80ddcc02e11d853265",
     "ui-select": "0.19.8"
@@ -29,8 +30,8 @@
     "babel-plugin-angularjs-annotate": "^0.10.0",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^3.6.0",
-    "esn-frontend-login": "github:openpaas-suite/esn-frontend-login#main",
     "dotenv-webpack": "^2.0.0",
+    "esn-frontend-login": "github:openpaas-suite/esn-frontend-login#main",
     "exports-loader": "^1.0.0",
     "expose-loader": "^1.0.0",
     "favicons-webpack-plugin": "^3.0.1",

--- a/src/linagora.esn.unifiedinbox/app/app.js
+++ b/src/linagora.esn.unifiedinbox/app/app.js
@@ -58,6 +58,7 @@
     'linagora.esn.james',
     'esn.inbox.libs',
     'esn.inbox-calendar',
+    'linagora.esn.unifiedinbox.linshare',
     angularDragula(angular) // eslint-disable-line no-undef
   ]);
 })(angular);
@@ -108,6 +109,7 @@ require('esn-frontend-common-libs/src/frontend/js/modules/previous-page');
 require('esn-frontend-common-libs/src/frontend/js/modules/dropdown-list');
 require('esn-frontend-common-libs/src/frontend/js/modules/box-overlay/box-overlay.module.js');
 
+require('esn-frontend-inbox-linshare/src/app/app.module');
 require('esn-frontend-inbox-calendar/src/app/app.module.js');
 
 require ('./components/attachment-alternative-uploader/attachment-alternative-uploader-modal.controller.js');

--- a/src/linagora.esn.unifiedinbox/app/inbox.less
+++ b/src/linagora.esn.unifiedinbox/app/inbox.less
@@ -23,3 +23,5 @@
 @import './components/banner/quota-banner/quota-banner';
 
 @import './search/search';
+
+@import 'esn-frontend-inbox-linshare/src/all.less';

--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -86,7 +86,8 @@ module.exports = {
           '/unifiedinbox/api',
           '/calendar/app',
           '/calendar/api',
-          '/linagora.esn.resource/api'
+          '/linagora.esn.resource/api',
+          '/linagora.esn.linshare/api'
         ],
         target: OPENPAAS_URL,
         disableHostCheck: true,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -22,7 +22,9 @@ module.exports = merge(commons, {
           path.resolve(__dirname, "node_modules/esn-frontend-inbox-calendar"),
           path.resolve(__dirname, "node_modules/esn-frontend-calendar/src/esn.calendar.libs"),
           path.resolve(__dirname, "node_modules/esn-frontend-calendar/src/esn.resource.libs"),
-          path.resolve(__dirname, "node_modules/esn-frontend-mailto-handler")
+          path.resolve(__dirname, "node_modules/esn-frontend-mailto-handler"),
+          path.resolve(__dirname, "node_modules/esn-frontend-linshare"),
+          path.resolve(__dirname, "node_modules/esn-frontend-inbox-linshare")
         ],
         exclude: [
           path.resolve(__dirname, "node_modules/esn-frontend-common-libs/src/frontend/components"),


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/53. Please also refer to these 2 PRs:

- https://github.com/OpenPaaS-Suite/esn-frontend-inbox-linshare/pull/3
- https://github.com/OpenPaaS-Suite/esn-frontend-linshare/pull/4

Demo (desktop):

![Demo-Linshare-Uploader-Desktop](https://user-images.githubusercontent.com/24670327/90240962-61f09f80-de54-11ea-94de-7b52258fccbc.gif)

Demo (mobile):

![Demo-Linshare-Uploader-Mobile](https://user-images.githubusercontent.com/24670327/90241173-bbf16500-de54-11ea-9d7e-ddf2d68cce29.gif)

Note: The dynamic directives' removal will be handled in another issue (https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/60).