### PR TITLE
esn-frontend-inbox#60: RemoveD all the dynamic directives related to the mail composer and mail attachments

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer-desktop.pug
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer-desktop.pug
@@ -40,7 +40,7 @@ form.form-horizontal.compose.ng-cloak(ng-submit="$ctrl.send()")
           md-menu-content(width="3")
             md-menu-item.md-indent(type="checkbox", ng-model="$ctrl.hasRequestedReadReceipt")
               | {{ 'Request a read receipt' | translate }}
-      div(dynamic-directive='inboxComposerExtraButtons')
+      inbox-linshare-composer-select-attachment(email="$ctrl.message")
       inbox-composer-attachments-selector(attachment-holder="$ctrl.attachmentHolder")
       button.btn.btn-primary(type="submit", value="submit", ng-disabled="$ctrl.isSendingMessage") {{ 'Send' | translate }}
         i.mdi.mdi-send

--- a/src/linagora.esn.unifiedinbox/app/config.js
+++ b/src/linagora.esn.unifiedinbox/app/config.js
@@ -1,15 +1,8 @@
 'use strict';
 
 angular.module('linagora.esn.unifiedinbox')
-  .config(injectAttachmentsActionList)
   .config(setDefaultIcon)
   .config(registerI18N);
-
-function injectAttachmentsActionList(dynamicDirectiveServiceProvider) {
-  const attachmentDownloadAction = new dynamicDirectiveServiceProvider.DynamicDirective(true, 'attachment-download-action');
-
-  dynamicDirectiveServiceProvider.addInjection('attachments-action-list', attachmentDownloadAction);
-}
 
 function setDefaultIcon($mdIconProvider) {
   $mdIconProvider.defaultIconSet('images/mdi/mdi.svg', 24);

--- a/src/linagora.esn.unifiedinbox/views/attachment/attachment-action-list.pug
+++ b/src/linagora.esn.unifiedinbox/views/attachment/attachment-action-list.pug
@@ -1,1 +1,3 @@
-.action-list(ng-click='$hide()', dynamic-directive='attachments-action-list')
+.action-list(ng-click='$hide()')
+  attachment-download-action
+  inbox-linshare-attachment-save-action(attachment='attachment')

--- a/src/linagora.esn.unifiedinbox/views/composer/subheader.pug
+++ b/src/linagora.esn.unifiedinbox/views/composer/subheader.pug
@@ -5,7 +5,7 @@ block left
 
 block right
   .inbox-composer-buttons.flex-vertical-centered
-    div(dynamic-directive='inboxMobileComposerExtraButtons')
+    inbox-linshare-composer-select-attachment(email="$ctrl.message", is-mobile="true")
     inbox-composer-attachments-selector(attachment-holder="$ctrl.attachmentHolder")
     button.send.btn.btn-link.flex-vertical-centered.hidden-xs(ng-click='$ctrl.send()', ng-disabled="$ctrl.isSendingMessage")
       | {{ 'Send' | translate }}


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/60. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-inbox-linshare/pull/5.