### PR TITLE
esn-frontend-inbox#74: Added missing @ngInject for the inboxMoveItemController

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/routes.js
+++ b/src/linagora.esn.unifiedinbox/app/routes.js
@@ -45,7 +45,7 @@ angular.module('linagora.esn.unifiedinbox')
           placement: 'center'
         });
       };
-      state.onExit = function(modalHolder) {
+      state.onExit = /* @ngInject */ function(modalHolder) {
         modalHolder.modal.hide();
       };
 


### PR DESCRIPTION
This PR continues to resolve https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/74. Without this `@ngInject` the move-to dialog cannot be closed.