### PR TITLE
esn-frontend-mailto#13: Added a 'cancelDestroy' method to InboxDraft that allows cancelling the destruction of a draft

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/components/composer/boxed/composer-boxed.pug
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/boxed/composer-boxed.pug
@@ -8,6 +8,7 @@ inbox-composer(
   on-send="onSend()",
   on-fail="onFail()"
   on-discard="onDiscard()",
+  on-discarding="onDiscarding(reopenDraft)",
   on-message-id-update="$setId($id)",
   on-title-update="$updateTitle($title)",
   on-try-close='$onTryClose(callback)',

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
@@ -168,6 +168,15 @@ angular.module('linagora.esn.unifiedinbox')
       _.forEach(self.message.attachments, _cancelAttachment);
 
       self.draft.destroy(options).then(self.onDiscard, self.onShow);
+
+      if (typeof self.onDiscarding !== 'function') return;
+
+      self.onDiscarding({
+        reopenDraft: () => {
+          self.draft.cancelDestroy();
+          self.onShow();
+        }
+      });
     }
 
     function _cancelAttachment(attachment) {

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.spec.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.spec.js
@@ -79,6 +79,7 @@ describe('The inboxComposerController controller', function() {
       },
       onSend: sinon.spy(),
       onSave: sinon.spy(),
+      onDiscarding: sinon.spy(),
       onDiscard: sinon.spy(),
       onHide: sinon.spy(),
       onShow: sinon.spy(),
@@ -734,6 +735,21 @@ describe('The inboxComposerController controller', function() {
       expect(ctrl.onShow).to.have.been.calledWith();
     });
 
+    it('should pass the function to reopen the draft before it is destroyed for good', function() {
+      ctrl.draft = {
+        destroy: () => $q.when(),
+        cancelDestroy: sinon.stub()
+      };
+
+      ctrl.onDiscarding = sinon.spy(function({ reopenDraft }) {
+        reopenDraft();
+
+        expect(ctrl.draft.cancelDestroy).to.have.been.called;
+        expect(ctrl.onShow).to.have.been.called;
+      });
+
+      ctrl.destroyDraft();
+    });
   });
 
   describe('onAttachmentsUpload', function() {

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.js
@@ -11,6 +11,7 @@ angular.module('linagora.esn.unifiedinbox')
       onSend: '&',
       onFail: '&',
       onSave: '&',
+      onDiscarding: '&',
       onDiscard: '&',
       onHide: '&',
       onShow: '&',


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-mailto/issues/13.

- TODO:

  - [x] Writing tests