### PR TITLE
esn-frontend-inbox#61: Added test timeout again and provided an environment variable to change the test timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,17 @@ Regarding **APP_GRID_ITEMS**, you can also provide it as a system variable for p
 ```sh
 APP_GRID_ITEMS="[{ \"name\": \"Calendar\", \"url\": \"https://dev.open-paas.org/calendar/\" }, { \"name\": \"Contacts\", \"url\": \"https://dev.open-paas.org/contacts/\" }, { \"name\": \"Inbox\", \"url\": \"http://dev.open-paas.org/inbox/\" }, { \"name\": \"Admin\", \"url\": \"https://dev.open-paas.org/admin/\" }, { \"name\": \"LinShare\", \"url\": \"https://user.linshare-4-0.integration-linshare.org/\" }]" npm run build:prod
 ```
+
+## Running tests
+
+You can run tests by executing the following command:
+
+```sh
+npm run test
+```
+
+Note that there is a 10000ms timeout by default. If you want to change that, simply pass the **TEST_TIMEOUT** environment variable:
+
+```sh
+TEST_TIMEOUT=2000 npm run test
+```

--- a/test/config/karma.conf.js
+++ b/test/config/karma.conf.js
@@ -4,14 +4,15 @@ const webpackConfig = require('../../webpack.test');
 
 module.exports = function(config) {
   const singleRun = process.env.SINGLE_RUN !== 'false';
+  // We need a timeout of at least 10000ms or else the tests will sometimes randomly
+  // fail because they exceed the default 2000ms timeout. This will happen often in
+  // the CI where the tests run slower than in our locals.
+  const timeout = process.env.TEST_TIMEOUT || 10000;
 
   config.set({
     client: {
       mocha: {
-        // We need a timeout of at least 5000ms or else the tests will sometimes randomly
-        // fail because they exceed the default 2000ms timeout. This will happen often in
-        // the CI where the tests run slower than in our locals.
-        timeout: 5000
+        timeout
       }
     },
     basePath: '../../',


### PR DESCRIPTION
Continues to resolve https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/61.