### PR TITLE
esn-frontend-mailto#34: The composer's 'send' method now notifies the calller with a way to reopen the composer when an mail fails to be sent

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/components/composer/boxed/composer-boxed.pug
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/boxed/composer-boxed.pug
@@ -6,7 +6,7 @@ inbox-composer(
   on-show="$show()",
   on-sending="onSending()",
   on-send="onSend()",
-  on-fail="onFail()"
+  on-fail="onFail(reopenComposer)"
   on-discard="onDiscard()",
   on-discarding="onDiscarding(reopenDraft)",
   on-message-id-update="$setId($id)",

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
@@ -8,8 +8,6 @@ require('../../services/attachment-upload/inbox-attachment-upload.service.js');
 require('../../services/draft/draft.js');
 require('../../services/attachment-provider-registry/attachment-provider-registry.service.js');
 
-// TODO: Write tests for this (https://github.com/OpenPaaS-Suite/esn-frontend-mailto/issues/2)
-
 angular.module('linagora.esn.unifiedinbox')
 
   .controller('inboxComposerController', function(

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
@@ -131,7 +131,7 @@ angular.module('linagora.esn.unifiedinbox')
           progressing: 'Your message is being sent...',
           success: 'Message sent',
           failure: function() {
-            if (typeof self.onFail === 'function') self.onFail();
+            if (typeof self.onFail === 'function') self.onFail({ reopenComposer: self.onShow });
 
             if (!Offline.state || Offline.state === 'down') {
               return 'You have been disconnected. Please check if the message was sent before retrying';

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.spec.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.spec.js
@@ -77,7 +77,9 @@ describe('The inboxComposerController controller', function() {
           email: 'email'
         }]
       },
+      onSending: sinon.spy(),
       onSend: sinon.spy(),
+      onFail: sinon.spy(),
       onSave: sinon.spy(),
       onDiscarding: sinon.spy(),
       onDiscard: sinon.spy(),
@@ -475,6 +477,12 @@ describe('The inboxComposerController controller', function() {
       expect(sendEmail).to.have.not.been.calledWith();
     });
 
+    it('should notify caller when email is being sent', function() {
+      ctrl.send();
+
+      expect(ctrl.onSending).to.have.been.called;
+    });
+
     it('should deduplicate recipients', function() {
       ctrl.message.cc = [{
         name: 'name',
@@ -596,6 +604,7 @@ describe('The inboxComposerController controller', function() {
 
       sendMessage();
 
+      expect(ctrl.onFail).to.have.been.called;
       expect(notificationFactory.strongError).to.have.been.calledWith('Error', 'Your message cannot be sent');
     });
 
@@ -608,6 +617,7 @@ describe('The inboxComposerController controller', function() {
 
       $rootScope.$digest();
 
+      expect(ctrl.onFail).to.have.been.called;
       expect(notificationFactory.strongError).to.have.been.calledWith('Error', 'You have been disconnected. Please check if the message was sent before retrying');
     });
 

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.spec.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.spec.js
@@ -604,7 +604,9 @@ describe('The inboxComposerController controller', function() {
 
       sendMessage();
 
-      expect(ctrl.onFail).to.have.been.called;
+      expect(ctrl.onFail).to.have.been.calledWith(sinon.match({
+        reopenComposer: ctrl.onShow
+      }));
       expect(notificationFactory.strongError).to.have.been.calledWith('Error', 'Your message cannot be sent');
     });
 
@@ -617,7 +619,9 @@ describe('The inboxComposerController controller', function() {
 
       $rootScope.$digest();
 
-      expect(ctrl.onFail).to.have.been.called;
+      expect(ctrl.onFail).to.have.been.calledWith(sinon.match({
+        reopenComposer: ctrl.onShow
+      }));
       expect(notificationFactory.strongError).to.have.been.calledWith('Error', 'You have been disconnected. Please check if the message was sent before retrying');
     });
 


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-mailto/issues/34. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-mailto/pull/40 for the actual usage of these changes.