### PR TITLE
esn-frontend-inbox#73: Removed IIFE and made the run block run again to register the mail attachment provider

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/module-registry.run.js
+++ b/src/linagora.esn.unifiedinbox/app/module-registry.run.js
@@ -1,13 +1,10 @@
+'use strict';
+
 require('./providers.js');
 
-(function(angular) {
+angular.module('linagora.esn.unifiedinbox')
 
-  'use strict';
-
-  angular.module('linagora.esn.unifiedinbox')
-
-    .run(function(inboxHostedMailAttachmentProvider, esnAttachmentListProviders, esnModuleRegistry, INBOX_MODULE_METADATA) {
-      esnAttachmentListProviders.add(inboxHostedMailAttachmentProvider);
-      esnModuleRegistry.add(INBOX_MODULE_METADATA);
-    });
-});
+  .run(function(inboxHostedMailAttachmentProvider, esnAttachmentListProviders, esnModuleRegistry, INBOX_MODULE_METADATA) {
+    esnAttachmentListProviders.add(inboxHostedMailAttachmentProvider);
+    esnModuleRegistry.add(INBOX_MODULE_METADATA);
+  });


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/73.

![image](https://user-images.githubusercontent.com/24670327/92364800-ce8e4f80-f11d-11ea-854b-9b6acab78990.png)

- [x] Test with production build (a.k.a. `npm run serve:prod`).