### PR TITLE
#122 fixed the composer and mailto triggering at the same time when dealing with event emails

### DIFF
--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -282,6 +282,14 @@ module.exports = {
             loader: 'pug-loader'
           }
         ]
+      },
+      {
+        test: path.resolve(__dirname, 'node_modules/esn-frontend-mailto-handler/src/lib/directive.js'),
+        use: [
+          {
+            loader: 'ignore-loader'
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
![composerEvents](https://user-images.githubusercontent.com/6764881/92746998-a69c2780-f37b-11ea-9b33-4dd7a26e440d.gif)


* [x] tested with production mode.