### PR TITLE
esn-frontend-mailto#29: Fixed a missing translation

### DIFF
--- a/src/esn.inbox.libs/i18n/en.json
+++ b/src/esn.inbox.libs/i18n/en.json
@@ -10,6 +10,7 @@
   "Request a read receipt": "Request a read receipt",
   "This draft has been discarded": "This draft has been discarded",
   "You have been disconnected. Please check if the message was sent before retrying": "You have been disconnected. Please check if the message was sent before retrying",
+  "You should save your email in order not to lose it": "You should save your email in order not to lose it",
   "Your device has lost Internet connection. Try later!": "Your device has lost Internet connection. Try later!",
   "Your email should have at least one recipient": "Your email should have at least one recipient",
   "Your message cannot be sent": "Your message cannot be sent",

--- a/src/esn.inbox.libs/i18n/fr.json
+++ b/src/esn.inbox.libs/i18n/fr.json
@@ -10,6 +10,7 @@
   "Request a read receipt": "Demander une confirmation de lecture",
   "This draft has been discarded": "Ce brouillon a été effacé",
   "You have been disconnected. Please check if the message was sent before retrying": "Vous avez été déconnecté. Vérifiez si le message a été envoyé avant de réessayer",
+  "You should save your email in order not to lose it": "Vous devez sauvegarder votre email pour ne pas le perdre",
   "Your device has lost Internet connection. Try later!": "La connexion a été coupée. Veuillez réessayer plus tard!",
   "Your email should have at least one recipient": "Votre courrier électronique devrait avoir au moins un destinataire",
   "Your message cannot be sent": "Votre message ne peut pas être envoyé",

--- a/src/esn.inbox.libs/i18n/ru.json
+++ b/src/esn.inbox.libs/i18n/ru.json
@@ -10,6 +10,7 @@
   "Request a read receipt": "Запросить подтверждение прочтения",
   "This draft has been discarded": "Этот черновик был отклонен",
   "You have been disconnected. Please check if the message was sent before retrying": "Вы были отключены. Перед повторной попыткой проверьте, было ли отправлено сообщение.",
+  "You should save your email in order not to lose it": "Вам следует сохранить электронную почту, чтобы не потерять ее",
   "Your device has lost Internet connection. Try later!": "Ваше устройство потеряло подключение к Интернету. Попробуйте позже!",
   "Your email should have at least one recipient": "В вашем письме должен быть хотя бы один получатель",
   "Your message cannot be sent": "Ваше сообщение не может быть отправлено",

--- a/src/esn.inbox.libs/i18n/vi.json
+++ b/src/esn.inbox.libs/i18n/vi.json
@@ -10,6 +10,7 @@
   "Request a read receipt": "Yêu cầu trạng thái đọc của thư",
   "This draft has been discarded": "Thư nháp đã được hủy",
   "You have been disconnected. Please check if the message was sent before retrying": "Mất kết nối. Kiểm tra trạng thái gửi của thư trước khi thử lại",
+  "You should save your email in order not to lose it": "Bạn nên lưu lại bản nháp thư để không bị mất",
   "Your device has lost Internet connection. Try later!": "Thiết bị của bạn đã mất kết nôi. Vui lòng thử lại sau!",
   "Your email should have at least one recipient": "Email phải chứa ít nhất 1 người nhận",
   "Your message cannot be sent": "Không gửi được thư",

--- a/src/esn.inbox.libs/i18n/zh.json
+++ b/src/esn.inbox.libs/i18n/zh.json
@@ -10,6 +10,7 @@
   "Request a read receipt": "要求已读回执",
   "This draft has been discarded": "草稿被丢弃",
   "You have been disconnected. Please check if the message was sent before retrying": "连接断开。请检查消息是否已发送，然后重试",
+  "You should save your email in order not to lose it": "您应该保存您的电子邮件以免丢失",
   "Your device has lost Internet connection. Try later!": "您的设置断开了连接。请稍后重试！",
   "Your email should have at least one recipient": "您的邮件需要至少一个收件人",
   "Your message cannot be sent": "您的消息无法被发送",

--- a/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/composer.controller.js
@@ -84,7 +84,7 @@ angular.module('linagora.esn.unifiedinbox')
     }
 
     function warnSaveDraft() {
-      self.needsSave && notificationFactory.weakError('Note', 'You should save your email to not loose it');
+      self.needsSave && notificationFactory.weakError('Note', 'You should save your email in order not to lose it');
     }
 
     function updateSaveFlag() {


### PR DESCRIPTION
Continues to resolve https://github.com/huy-ta/esn-frontend-mailto/issues/29.