### PR TITLE
#128 fix mobile composer close button using history.back as previous page

### DIFF
--- a/src/linagora.esn.unifiedinbox/views/partials/subheader/close-button.pug
+++ b/src/linagora.esn.unifiedinbox/views/partials/subheader/close-button.pug
@@ -3,5 +3,5 @@ button.btn.btn-link.close.button.hidden-xs(href='', esn-back-button='unifiedinbo
     i.mdi.mdi-close.mdi-margin-right
     span {{ 'Cancel' | translate }}
 
-button.btn.btn-link.btn-icon.close.button.visible-xs(href='', esn-back-button='unifiedinbox')
+button.btn.btn-link.btn-icon.close.button.visible-xs(prevent-history-back='', href='', esn-back-button='unifiedinbox')
   i.mdi.mdi-close


### PR DESCRIPTION
![mobile-composer-fix](https://user-images.githubusercontent.com/6764881/93190397-3acf0b80-f73b-11ea-847b-0942af8e5524.gif)
