### PR TITLE
#218 Fix underline link in message list view

### DIFF
--- a/src/linagora.esn.unifiedinbox/css/modules/listItems.less
+++ b/src/linagora.esn.unifiedinbox/css/modules/listItems.less
@@ -128,6 +128,7 @@
         max-height: @inbox-list-item-height-xl;
         color: @text-color;
         display: block;
+        text-decoration: none;
 
         .media-body {
           .flex-space-between;


### PR DESCRIPTION
**Demo:**
https://streamable.com/t2320a

Fixed by adding a css property to the inbox message item, the problem doesn't come form signature, but rather from the content of the transferred mail.
