### PR TITLE
#250 Remove duplicate calls

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/controllers.js
+++ b/src/linagora.esn.unifiedinbox/app/controllers.js
@@ -52,7 +52,6 @@ require('./services/common/inbox-utils.service.js');
       $scope.$on(INBOX_EVENTS.DRAFT_CREATED, handleNewDraft);
       $scope.$on(INBOX_EVENTS.UNAVAILABLE_ACCOUNT_DETECTED, handleUnavailableAccount.bind(this));
 
-      _getVacationActivated();
       _getQuotaStatus();
 
       $scope.$on(INBOX_EVENTS.VACATION_STATUS, _getVacationActivated);

--- a/src/linagora.esn.unifiedinbox/app/controllers.spec.js
+++ b/src/linagora.esn.unifiedinbox/app/controllers.spec.js
@@ -367,16 +367,6 @@ describe('The linagora.esn.unifiedinbox module controllers', function() {
       expect(scope.loadRecentItems).to.have.not.been.calledWith();
     });
 
-    it('should call _getVacationActivated  and return vacation activated', function() {
-      jmapClient.getVacationResponse = function() {
-        return $q.when({ isActivated: true });
-      };
-
-      initController('unifiedInboxController');
-
-      expect(inboxJmapItemService.getVacationActivated).to.have.been.called;
-    });
-
     it('should call _getQuotaStatus and return quota activated', function() {
       inboxUserQuotaService.getUserQuotaInfo = sinon.spy(function() {
         return $q.when({ quotaLevel: 'major' });


### PR DESCRIPTION
 1. Removing duplicate call for **getVacationResponses** 
Already called here [vacation-banner.controller.js](https://github.com/OpenPaaS-Suite/esn-frontend-inbox/blob/2d36f27777490dddb960e7ce54097022a086df76/src/linagora.esn.unifiedinbox/app/components/banner/vacation-banner/vacation-banner.controller.js#L14) 