### PR TITLE
Add mailbox max changes constant and manage the cannotCalculateChanges case

### DIFF
--- a/src/esn.inbox.libs/app/app.constants.js
+++ b/src/esn.inbox.libs/app/app.constants.js
@@ -108,4 +108,5 @@ angular.module('esn.inbox.libs')
     TEMPLATES: 'templates'
   })
   .constant('INFINITE_MAILBOXES_POLLING_INTERVAL', 60 * 1000)
-  .constant('INBOX_SEARCH_DEBOUNCE_DELAY', 1000);
+  .constant('INBOX_SEARCH_DEBOUNCE_DELAY', 1000)
+  .constant('JMAP_MAILBOX_MAX_CHANGES', 128);


### PR DESCRIPTION
When the server responds with a `cannotCalculateChanges` error, all mailboxes are fetched again.