### PR TITLE
#347 display attachments card with only noInline attachments

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/directives/main.js
+++ b/src/linagora.esn.unifiedinbox/app/directives/main.js
@@ -258,8 +258,10 @@ require('../services.js');
           }.bind(this));
 
           if ($scope.email && $scope.email.attachments) {
-            $scope.attachmentsNumber = $scope.email.attachments.length;
-            $scope.attachmentsSize = $scope.email.attachments.map(attachment => attachment.size).reduce((sum, size) => sum + size, 0);
+            $scope.noInlineAttachments = $scope.email.attachments.filter(attachment => !attachment.isInline) || [];
+
+            $scope.attachmentsNumber = $scope.noInlineAttachments.length;
+            $scope.attachmentsSize = $scope.noInlineAttachments.map(attachment => attachment.size).reduce((sum, size) => sum + size, 0);
           }
 
           this.toggleIsCollapsed = function(email) {

--- a/src/linagora.esn.unifiedinbox/views/partials/email.pug
+++ b/src/linagora.esn.unifiedinbox/views/partials/email.pug
@@ -36,7 +36,7 @@
         message="email"
       )
 
-    div(ng-if="email.attachments.length > 0")
+    div(ng-if="attachmentsNumber > 0")
       md-card
         md-card-header(ng-click="isExpand = !isExpand")
           md-card-header-text.flex.flex-start
@@ -49,7 +49,7 @@
               md-icon(md-svg-icon="{{ isExpand ? 'chevron-double-up' : 'chevron-double-down' }}")
 
         md-card-content.lv-footer.attachments(ng-class="{ expand: isExpand, 'more-6':attachmentsNumber > 6 }")
-          inbox-attachment(ng-repeat="attachment in email.attachments", ng-if="::!attachment.isInline", attachment="::attachment")
+          inbox-attachment(ng-repeat="attachment in noInlineAttachments", attachment="::attachment")
 
     .text-center(ng-if="!email.loaded", openpaas-logo-spinner, spinner-start-active="1", spinner-size="0.4")
 


### PR DESCRIPTION
BEFORE 

![Capture d’écran de 2021-04-30 17-24-17](https://user-images.githubusercontent.com/11298249/116739963-a036ea80-a9f4-11eb-9d0b-ce217d3062fb.png)



AFTER

![Capture d’écran de 2021-04-30 20-36-47](https://user-images.githubusercontent.com/11298249/116739974-a3ca7180-a9f4-11eb-9a98-76d8067c8e7c.png)
